### PR TITLE
changes to use count

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -1,44 +1,44 @@
 # name of the queue
 output "name" {
-  value = "${azurerm_template_deployment.queue.*.outputs["queueName"]}"
+  value = "${join("",azurerm_template_deployment.queue.*.outputs["queueName"])}"
 }
 
 # primary connection string for send operations
 output "primary_send_connection_string" {
-  value = "${azurerm_template_deployment.queue.*.outputs["primarySendConnectionString"]}"
+  value = "${join("",azurerm_template_deployment.queue.*.outputs["primarySendConnectionString"])}"
 }
 
 # secondary connection string for send operations
 output "secondary_send_connection_string" {
-  value = "${azurerm_template_deployment.queue.*.outputs["secondarySendConnectionString"]}"
+  value = "${join("",azurerm_template_deployment.queue.*.outputs["secondarySendConnectionString"])}"
 }
 
 # primary shared access key with send rights
 output "primary_send_shared_access_key" {
-  value = "${azurerm_template_deployment.queue.*.outputs["primarySendSharedAccessKey"]}"
+  value = "${join("",azurerm_template_deployment.queue.*.outputs["primarySendSharedAccessKey"])}"
 }
 
 # secondary shared access key with send rights
 output "secondary_send_shared_access_key" {
-  value = "${azurerm_template_deployment.queue.*.outputs["secondarySendSharedAccessKey"]}"
+  value = "${join("",azurerm_template_deployment.queue.*.outputs["secondarySendSharedAccessKey"])}"
 }
 
 # primary connection string for listen operations
 output "primary_listen_connection_string" {
-  value = "${azurerm_template_deployment.queue.*.outputs["primaryListenConnectionString"]}"
+  value = "${join("",azurerm_template_deployment.queue.*.outputs["primaryListenConnectionString"])}"
 }
 
 # secondary connection string for listen operations
 output "secondary_listen_connection_string" {
-  value = "${azurerm_template_deployment.queue.*.outputs["secondaryListenConnectionString"]}"
+  value = "${join("",azurerm_template_deployment.queue.*.outputs["secondaryListenConnectionString"])}"
 }
 
 # primary shared access key with listen rights
 output "primary_listen_shared_access_key" {
-  value = "${azurerm_template_deployment.queue.*.outputs["primaryListenSharedAccessKey"]}"
+  value = "${join("",azurerm_template_deployment.queue.*.outputs["primaryListenSharedAccessKey"])}"
 }
 
 # secondary shared access key with listen rights
 output "secondary_listen_shared_access_key" {
-  value = "${azurerm_template_deployment.queue.*.outputs["secondaryListenSharedAccessKey"]}"
+  value = "${join("",azurerm_template_deployment.queue.*.outputs["secondaryListenSharedAccessKey"])}"
 }

--- a/output.tf
+++ b/output.tf
@@ -1,44 +1,44 @@
 # name of the queue
 output "name" {
-  value = "${azurerm_template_deployment.queue.outputs["queueName"]}"
+  value = "${azurerm_template_deployment.queue.*.outputs["queueName"]}"
 }
 
 # primary connection string for send operations
 output "primary_send_connection_string" {
-  value = "${azurerm_template_deployment.queue.outputs["primarySendConnectionString"]}"
+  value = "${azurerm_template_deployment.queue.*.outputs["primarySendConnectionString"]}"
 }
 
 # secondary connection string for send operations
 output "secondary_send_connection_string" {
-  value = "${azurerm_template_deployment.queue.outputs["secondarySendConnectionString"]}"
+  value = "${azurerm_template_deployment.queue.*.outputs["secondarySendConnectionString"]}"
 }
 
 # primary shared access key with send rights
 output "primary_send_shared_access_key" {
-  value = "${azurerm_template_deployment.queue.outputs["primarySendSharedAccessKey"]}"
+  value = "${azurerm_template_deployment.queue.*.outputs["primarySendSharedAccessKey"]}"
 }
 
 # secondary shared access key with send rights
 output "secondary_send_shared_access_key" {
-  value = "${azurerm_template_deployment.queue.outputs["secondarySendSharedAccessKey"]}"
+  value = "${azurerm_template_deployment.queue.*.outputs["secondarySendSharedAccessKey"]}"
 }
 
 # primary connection string for listen operations
 output "primary_listen_connection_string" {
-  value = "${azurerm_template_deployment.queue.outputs["primaryListenConnectionString"]}"
+  value = "${azurerm_template_deployment.queue.*.outputs["primaryListenConnectionString"]}"
 }
 
 # secondary connection string for listen operations
 output "secondary_listen_connection_string" {
-  value = "${azurerm_template_deployment.queue.outputs["secondaryListenConnectionString"]}"
+  value = "${azurerm_template_deployment.queue.*.outputs["secondaryListenConnectionString"]}"
 }
 
 # primary shared access key with listen rights
 output "primary_listen_shared_access_key" {
-  value = "${azurerm_template_deployment.queue.outputs["primaryListenSharedAccessKey"]}"
+  value = "${azurerm_template_deployment.queue.*.outputs["primaryListenSharedAccessKey"]}"
 }
 
 # secondary shared access key with listen rights
 output "secondary_listen_shared_access_key" {
-  value = "${azurerm_template_deployment.queue.outputs["secondaryListenSharedAccessKey"]}"
+  value = "${azurerm_template_deployment.queue.*.outputs["secondaryListenSharedAccessKey"]}"
 }


### PR DESCRIPTION
must use splat syntax to access azurerm_template_deployment.queue attribute "outputs", because it has "count" set

after we start using count we got error:
https://build-beta.platform.hmcts.net/view/BSP/job/HMCTS_BSP/job/reform-scan-shared-infra/job/master/8


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
