### PR TITLE
Make max message size for queue configurable for queue module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ resource "azurerm_servicebus_queue" "servicebus_queue" {
   requires_duplicate_detection            = var.requires_duplicate_detection
   duplicate_detection_history_time_window = var.duplicate_detection_history_time_window
   requires_session                        = var.requires_session
+  max_message_size_in_kilobytes           = var.max_message_size_in_kilobytes
 
   max_size_in_megabytes                = 1024
   default_message_ttl                  = "P10675199DT2H48M5.4775807S"

--- a/variables.tf
+++ b/variables.tf
@@ -42,3 +42,9 @@ variable "requires_session" {
   description = "A value that indicates whether the queue requires sessions"
   default     = false
 }
+
+variable "max_message_size_in_kilobytes" {
+  type        = string
+  description = "Integer value which controls the maximum size of a message allowed on the queue for Premium SKU"
+  default     = "1024"
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCSCI-153

### Change description ###

-  In SSCS we are seeing our callback orchestrator fails to post messages on the queue as they sometimes exceeds 1MB limit. 
- Although we don't want to post such large data on the queue in the short term we want to increase the size slightly till we have strategic fix otherwise it keeps failing and takes lot of effort and time to resolve it manually.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
