### PR TITLE
Set max_message_size_in_kilobytes default to null

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -46,5 +46,5 @@ variable "requires_session" {
 variable "max_message_size_in_kilobytes" {
   type        = string
   description = "Integer value which controls the maximum size of a message allowed on the queue for Premium SKU"
-  default     = "1024"
+  default     = null
 }


### PR DESCRIPTION
### Change description ###

* Some queues dont support max_message_size_in_kilobytes argument
* Set this to be conditional argument using default = null

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
